### PR TITLE
Fix #10

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,8 @@ export default class Multiplayer extends Plugin {
     this.addSettingTab(new MultiplayerSettingTab(this.app, this));
 
     this.settings.sharedFolders.forEach((sharedFolder: SharedFolderSettings) => {
-      const newSharedFolder = new SharedFolder(sharedFolder)
+      //@ts-expect-error
+      const newSharedFolder = new SharedFolder(sharedFolder, this.app.vault.adapter.getbasePath())
       this.sharedFolders.push(newSharedFolder)
     })
    
@@ -277,7 +278,8 @@ class SharedFolderModal extends Modal {
             const settings = {guid: randomUUID(), path: path, signalingServers, password}
             this.plugin.settings.sharedFolders.push(settings)
             this.plugin.saveSettings();
-            this.plugin.sharedFolders.push(new SharedFolder(settings))
+            //@ts-expect-error
+            this.plugin.sharedFolders.push(new SharedFolder(settings, this.app.vault.adapter.getBasePath()))
             this.plugin.addIcons()
             this.close();
           }
@@ -312,6 +314,7 @@ class UnshareFolderModal extends Modal {
       const button = contentEl.createEl('button', { text: 'Unshare Folder', attr: { class: 'btn btn-danger' } })
       button.onClickEvent((ev) => {
         this.plugin.settings.sharedFolders = this.plugin.settings.sharedFolders.filter(el => el.path !== sharedFolder.basePath)
+        this.plugin.sharedFolders = this.plugin.sharedFolders.filter(el => el.basePath !== sharedFolder.basePath)
         this.plugin.saveSettings()
         this.plugin.removeIcon(this.folder.basePath)
         this.folder.docs.forEach(doc => {

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -8,6 +8,7 @@ import { Extension} from '@codemirror/state'
 import { IndexeddbPersistence } from 'y-indexeddb'
 import * as random from 'lib0/random'
 import { randomUUID } from "crypto";
+import { existsSync, readFileSync} from "fs"
 
 
 export interface SharedFolderSettings {
@@ -36,8 +37,10 @@ const usercolors = [
   docs: Map<string, SharedDoc> // Maps guids to SharedDocs
   private _persistence: IndexeddbPersistence
   private _provider: WebrtcProvider
+  private _vaultRoot:string
 
-  constructor({guid, path, signalingServers, password}: SharedFolderSettings) {
+  constructor({guid, path, signalingServers, password}: SharedFolderSettings, vaultRoot: string) {
+    this._vaultRoot = vaultRoot + "/"
     this.basePath = path
     this.guid = guid
     this.root = new Y.Doc()
@@ -72,8 +75,14 @@ const usercolors = [
       throw new Error('Path is not in shared folder: ' + path)
     }
 
+    var contents = ""
+    if (existsSync(this._vaultRoot+path)) {
+      contents = readFileSync(path, "utf-8")
+    }
+
     const guid = this.ids.get(path) || randomUUID()
     const doc = new SharedDoc(path, guid)
+    doc.ydoc.getText("contents").insert(0, contents)
     this.docs.set(guid, doc)
     this.ids.set(path, guid)
     

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -60,23 +60,23 @@ const usercolors = [
       const doc = this.docs.get(id)
       if (doc !== undefined) {
         return doc
-      } 
-    } 
-
-    if (create) 
+      } else {
+        return this.createDoc(path, true)
+      }
+    } else if (create) 
       return this.createDoc(path)
     else
       throw new Error('No shared doc for path: ' + path)
   }
 
   // Create a new shared doc
-  createDoc(path: string): SharedDoc {
+  createDoc(path: string, loadFromDisk:boolean = false): SharedDoc {
     if (!path.startsWith(this.basePath)) {
       throw new Error('Path is not in shared folder: ' + path)
     }
 
     var contents = ""
-    if (existsSync(this._vaultRoot+path)) {
+    if (loadFromDisk && existsSync(this._vaultRoot+path)) {
       contents = readFileSync(path, "utf-8")
     }
 


### PR DESCRIPTION
No longer blows away local files on first load. CAVEAT EMPTOR: If there's a remote file that has content in it, that will blow away local content. Only if there's local content AND there's no corresponding remote content will the local content be persisted.